### PR TITLE
Adding queryAll functions to WWW::Salesforce

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Perl extension WWW::Salesforce.
 
+0.14 Fri Jan 06 17:23:00 2010 PST
+    - Added queryAll and do_queryAll functionality
+
 0.13 Sat Oct 30 14:05:00 2010 PST
 
     - Add LICENSE file per Fedora maintainer request

--- a/README
+++ b/README
@@ -76,6 +76,20 @@ DESCRIPTION
             is helpful in producing paginated results, or fetch small sets
             of data at a time.
 
+    queryAll( HASH )
+        Executes a query against the specified object and returns data that
+        matches the specified criteria including deleted and archived records.
+
+        query
+            The query string to use for the query. The query string takes
+            the form of a *basic* SQL statement. For example, "SELECT
+            Id,Name FROM Account".
+
+        limit
+            This sets the batch size, or size of the result returned. This
+            is helpful in producing paginated results, or fetch small sets
+            of data at a time.
+
     queryMore( HASH )
         Retrieves the next batch of objects from a "query".
 

--- a/t/WWW-Salesforce.t
+++ b/t/WWW-Salesforce.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 29;
+use Test::More tests => 31;
 
 use SOAP::Lite;
 
@@ -25,7 +25,7 @@ if ( !$automated && !$ENV{SFDC_USER} &&
 
 SKIP: {
 
-    skip $skip_reason, 28, if $skip_reason;
+    skip $skip_reason, 30, if $skip_reason;
 
     my $user = $ENV{SFDC_USER};
     my $pass = $ENV{SFDC_PASS} . $ENV{SFDC_TOKEN};
@@ -97,6 +97,23 @@ SKIP: {
             $res =
               $sforce->queryMore( 'queryLocator' => $locator, 'limit' => 5 );
             ok( $res, "queryMore accounts" ) or diag($!);
+        }
+    }
+
+    #test -- queryAll
+    {
+        my $res =
+          $sforce->queryAll( 'query' => 'select id from account', 'limit' => 5 );
+        ok( $res, "queryAll accounts" ) or diag($!);
+
+        #test -- queryMore against queryAll
+      SKIP: {
+            my $locator = $res->valueof('//queryAllResponse/result/queryLocator')
+              if $res;
+            skip( "No more results to queryMore for", 1 ) unless $locator;
+            $res =
+              $sforce->queryMore( 'queryLocator' => $locator, 'limit' => 5 );
+            ok( $res, "queryMore all accounts" ) or diag($!);
         }
     }
 


### PR DESCRIPTION
Hi,

So $WORK has me doing things with salesforce and have a need to retrieve archived and deleted records from salesforce. The problem this poses is the query functions used in the existing WWW::Salesforce calls automatically filter isArchived and isDeleted records on the salesforce side. To retrieve these records you need to use an alternate salesforce call of queryAll. So here's a set of functions implementing queryAll calls to salesforce. For the most parts they are copies of the query() functions and they are working correctly for all of my use cases and the test I added. 

I would appreciate your consideration in releasing these changes or letting me know what else might need to be done to get such functionality added to the package

Thanks
-Chris
