### PR TITLE
Update Salesforce.pm

### DIFF
--- a/lib/WWW/Salesforce.pm
+++ b/lib/WWW/Salesforce.pm
@@ -174,6 +174,28 @@ sub describeGlobal {
 }
 
 #**************************************************************************
+# logout()     -- API
+#   -- Ends the session for the logged-in user issuing the call. No arguments are needed.
+#   Useful to avoid hitting the limit of ten open sessions per login.
+#   http://www.salesforce.com/us/developer/docs/api/Content/sforce_api_calls_logout.htm
+#**************************************************************************
+sub logout {
+    my $self = shift;
+    
+    my $client = $self->get_client(1);
+    my $method =
+      SOAP::Data->name("logout")->prefix($SF_PREFIX)->uri($SF_URI);
+    my $r = $client->call( $method, $self->get_session_header() );
+    unless ($r) {
+        die "could not call method $method";
+    }    
+    if ( $r->fault() ) {
+        die( $r->faultstring() );
+    }    
+    return $r;
+}
+
+#**************************************************************************
 # describeLayout()     -- API
 #   -- retrieve information about the layout (presentation of data to
 #       users) for a given object type.


### PR DESCRIPTION
Added logout() subroutine.
Ends the session for the logged-in user issuing the call. No arguments are needed.
Useful to avoid hitting the limit of ten open sessions per login.

See http://www.salesforce.com/us/developer/docs/api/Content/sforce_api_calls_logout.htm
