### PR TITLE
Test correction for "skip all" case

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,8 +1,10 @@
 Revision history for Perl extension WWW::Salesforce.
 
-0.19 May 24 2013
+0.19 May 27 2013
     - Added web proxy support ($WWW::Salesforce::WEB_PROXY=http://my.proxy.com:8080)
     - added unit tests
+    - added the ability to override the API URL, for use within salesforce.com
+    - above by Dave Clendenan
 
 0.18 Mar 22 2013
     - Added logout() subroutine to end session for logged in user

--- a/t/WWW-Salesforce.t
+++ b/t/WWW-Salesforce.t
@@ -30,6 +30,9 @@ if ($ENV{SFDC_URL}) {
     $WWW::Salesforce::SF_PROXY = $ENV{SFDC_URL};
 }
 
+diag "Running tests with WWW::Salesforce version " . WWW::Salesforce->VERSION .
+        " against $WWW::Salesforce::SF_PROXY\n";
+
 SKIP: {
 
     skip $skip_reason, 35, if $skip_reason;


### PR DESCRIPTION
- Correct the "variables unset" behaviour where all connecting tests are
  skipped (now skipping 35 tests)
- Move the version/URL diag to the case where the tests actually run
